### PR TITLE
Fix UTF-8 locale in Docker image to support non-ASCII paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,8 @@ EXPOSE 4568
 # Default to headless mode
 ENV MANGATAN_HEADLESS=true
 
+# Ensure UTF-8 filesystem encoding for Java
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 ENTRYPOINT ["/app/mangatan"]


### PR DESCRIPTION
Sets `LANG` and `LC_ALL` to `C.UTF-8` in the Docker image. This fixes the `InvalidPathException` Java error when downloading chapters with non-ASCII characters in the title.

Verified by building the Docker image locally and testing downloads with Unicode titles. Closes #21.