### PR TITLE
Fix Mangatan's chapter indexing logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ avif-decode = "1.0"
 axum = { version = "0.8.7", features = ["macros", "multipart", "ws"] }
 base64 = "0.22"
 bytes = "1.11"
-chrome_lens_ocr = "0.2.3"
+chrome_lens_ocr = "0.3.0"
 clap = { version = "4.0", features = ["env", "derive"] }
 directories = "6.0"
 eframe = "0.33"


### PR DESCRIPTION
A chapter node has two identifiers, `chapter_number` and `id`, and we should always use id for graphql query