### PR TITLE
Downscale screenshot to fit under optional maximum width/height (px) values

### DIFF
--- a/WebUI/src/Manatan/components/CropperModal.tsx
+++ b/WebUI/src/Manatan/components/CropperModal.tsx
@@ -10,6 +10,8 @@ interface CropperModalProps {
     onComplete: (croppedImage: string) => void;
     onCancel: () => void;
     quality: number;
+    downscaleMaxWidth?: number;
+    downscaleMaxHeight?: number;
 }
 
 export const CropperModal: React.FC<CropperModalProps> = ({ 
@@ -17,7 +19,9 @@ export const CropperModal: React.FC<CropperModalProps> = ({
     spreadData,
     onComplete, 
     onCancel,
-    quality 
+    quality,
+    downscaleMaxWidth,
+    downscaleMaxHeight
 }) => {
     // Default crop is 80% of the image, centered
     const [crop, setCrop] = useState<Crop>({
@@ -89,7 +93,9 @@ export const CropperModal: React.FC<CropperModalProps> = ({
                     spreadData.leftSrc,
                     spreadData.rightSrc,
                     pixelCrop,
-                    quality
+                    quality,
+                    downscaleMaxWidth,
+                    downscaleMaxHeight
                 );
 
             } else if (singleImgRef.current && imageSrc) {
@@ -107,7 +113,9 @@ export const CropperModal: React.FC<CropperModalProps> = ({
                     imageSrc, 
                     pixelCrop, 
                     quality,
-                    0
+                    0,
+                    downscaleMaxWidth,
+                    downscaleMaxHeight
                 );
             }
 

--- a/WebUI/src/Manatan/components/DictionaryView.tsx
+++ b/WebUI/src/Manatan/components/DictionaryView.tsx
@@ -624,7 +624,7 @@ const AnkiButtons: React.FC<{
                         fields: [imgField]
                     };
                 } else {
-                    const b64 = await imageUrlToBase64Webp(dictPopup.context.imgSrc, settings.ankiImageQuality || 0.92);
+                    const b64 = await imageUrlToBase64Webp(dictPopup.context.imgSrc, settings.ankiImageQuality || 0.92, settings.ankiDownscaleMaxWidth, settings.ankiDownscaleMaxHeight);
                     if (b64) {
                         pictureData = {
                             data: b64.split(';base64,')[1],

--- a/WebUI/src/Manatan/components/DictionaryView.tsx
+++ b/WebUI/src/Manatan/components/DictionaryView.tsx
@@ -696,6 +696,8 @@ const AnkiButtons: React.FC<{
                     onComplete={(b64) => { setShowCropper(false); addNoteToAnki(b64); }}
                     onCancel={() => setShowCropper(false)}
                     quality={settings.ankiImageQuality || 0.92}
+                    downscaleMaxWidth={settings.ankiDownscaleMaxWidth}
+                    downscaleMaxHeight={settings.ankiDownscaleMaxHeight}
                 />,
                 document.body
             )}

--- a/WebUI/src/Manatan/components/SettingsModal.tsx
+++ b/WebUI/src/Manatan/components/SettingsModal.tsx
@@ -1072,6 +1072,35 @@ ${detail}`,
                                         </label>
                                     </div>
 
+                                    <div style={{ marginBottom: '15px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>
+                                        <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Downscale Image</div>
+                                        <div style={{ display: 'grid', gridTemplateColumns: 'min-content 1fr', gap: '8px', alignItems: 'center' }}>
+                                            <label htmlFor="ankiDownscaleMaxWidth" style={{ whiteSpace: 'nowrap' }}>Max Width:</label>
+                                            <input 
+                                                id="ankiDownscaleMaxWidth"
+                                                type="number" 
+                                                min="0"
+                                                value={localSettings.ankiDownscaleMaxWidth ?? ''}
+                                                onChange={(e) => handleChange('ankiDownscaleMaxWidth', e.target.value ? parseInt(e.target.value, 10) : undefined)}
+                                                placeholder="e.g. 500"
+                                                style={{ width: '100px' }}
+                                            />
+                                            <label htmlFor="ankiDownscaleMaxHeight" style={{ whiteSpace: 'nowrap' }}>Max Height:</label>
+                                            <input 
+                                                id="ankiDownscaleMaxHeight"
+                                                type="number" 
+                                                min="0"
+                                                value={localSettings.ankiDownscaleMaxHeight ?? ''}
+                                                onChange={(e) => handleChange('ankiDownscaleMaxHeight', e.target.value ? parseInt(e.target.value, 10) : undefined)}
+                                                placeholder="e.g. 500"
+                                                style={{ width: '100px' }}
+                                            />
+                                        </div>
+                                        <div style={{ opacity: 0.5, fontSize: '0.9em', marginTop: '4px' }}>
+                                            Leave blank to keep original size. Images will be downscaled while maintaining aspect ratio.
+                                        </div>
+                                    </div>
+
                                     {!localSettings.enableYomitan && (
                                         <div style={{ marginBottom: '15px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>
                                             <label style={{ ...checkboxLabelStyle, marginBottom: '0' }}>

--- a/WebUI/src/Manatan/components/SettingsModal.tsx
+++ b/WebUI/src/Manatan/components/SettingsModal.tsx
@@ -152,6 +152,22 @@ const getSingleGlossaryName = (value: string): string | null => {
     }
     return null;
 };
+
+const DOWNSCALE_OPTIONS = [
+    { value: '', label: 'Original Size' },
+    { value: '240', label: '240' },
+    { value: '360', label: '360' },
+    { value: '480', label: '480' },
+    { value: '720', label: '720' },
+    { value: '900', label: '900' },
+    { value: '1080', label: '1080' },
+    { value: '1200', label: '1200' },
+    { value: '1440', label: '1440' },
+    { value: '1600', label: '1600' },
+    { value: '1920', label: '1920' },
+    { value: '2560', label: '2560' },
+    { value: '3840', label: '3840' },
+];
 export const SettingsModal: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     const { settings, setSettings, showConfirm, showAlert, showProgress, closeDialog, showDialog, openSetup } = useOCR();
     const [localSettings, setLocalSettings] = useState(settings);
@@ -1053,6 +1069,41 @@ ${detail}`,
                                         <div style={{ gridColumn: '1 / -1', fontSize: '0.85em', color: '#aaa' }}>
                                             Image compression quality for screenshots sent to Anki (0-1).
                                         </div>
+
+                                        {/* Downscale settings */}
+                                        <div style={{ gridColumn: '1 / -1', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+                                            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                                                <label htmlFor="ankiDownscaleMaxWidth">Max Image Width (px)</label>
+                                                    <select 
+                                                        id="ankiDownscaleMaxWidth"
+                                                        value={localSettings.ankiDownscaleMaxWidth ?? ''}
+                                                        onChange={(e) => handleChange('ankiDownscaleMaxWidth', e.target.value ? parseInt(e.target.value, 10) : undefined)}
+                                                    >
+                                                        {DOWNSCALE_OPTIONS.map(opt => (
+                                                            <option key={`width-${opt.value}`} value={opt.value}>
+                                                                {opt.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                            </div>
+                                            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                                                <label htmlFor="ankiDownscaleMaxHeight">Max Image Height (px)</label>
+                                                    <select 
+                                                        id="ankiDownscaleMaxHeight"
+                                                        value={localSettings.ankiDownscaleMaxHeight ?? ''}
+                                                        onChange={(e) => handleChange('ankiDownscaleMaxHeight', e.target.value ? parseInt(e.target.value, 10) : undefined)}
+                                                    >
+                                                        {DOWNSCALE_OPTIONS.map(opt => (
+                                                            <option key={`height-${opt.value}`} value={opt.value}>
+                                                                {opt.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                            </div>
+                                            <div style={{ gridColumn: '1 / -1', fontSize: '0.85em', color: '#aaa' }}>
+                                                If the screenshot exceeds the max width or height, it will be downscaled.
+                                            </div>
+                                        </div>
                                     </div>
 
                                     <div style={{ marginBottom: '15px', marginTop: '10px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>
@@ -1072,34 +1123,7 @@ ${detail}`,
                                         </label>
                                     </div>
 
-                                    <div style={{ marginBottom: '15px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>
-                                        <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Downscale Image</div>
-                                        <div style={{ display: 'grid', gridTemplateColumns: 'min-content 1fr', gap: '8px', alignItems: 'center' }}>
-                                            <label htmlFor="ankiDownscaleMaxWidth" style={{ whiteSpace: 'nowrap' }}>Max Width:</label>
-                                            <input 
-                                                id="ankiDownscaleMaxWidth"
-                                                type="number" 
-                                                min="0"
-                                                value={localSettings.ankiDownscaleMaxWidth ?? ''}
-                                                onChange={(e) => handleChange('ankiDownscaleMaxWidth', e.target.value ? parseInt(e.target.value, 10) : undefined)}
-                                                placeholder="e.g. 500"
-                                                style={{ width: '100px' }}
-                                            />
-                                            <label htmlFor="ankiDownscaleMaxHeight" style={{ whiteSpace: 'nowrap' }}>Max Height:</label>
-                                            <input 
-                                                id="ankiDownscaleMaxHeight"
-                                                type="number" 
-                                                min="0"
-                                                value={localSettings.ankiDownscaleMaxHeight ?? ''}
-                                                onChange={(e) => handleChange('ankiDownscaleMaxHeight', e.target.value ? parseInt(e.target.value, 10) : undefined)}
-                                                placeholder="e.g. 500"
-                                                style={{ width: '100px' }}
-                                            />
-                                        </div>
-                                        <div style={{ opacity: 0.5, fontSize: '0.9em', marginTop: '4px' }}>
-                                            Leave blank to keep original size. Images will be downscaled while maintaining aspect ratio.
-                                        </div>
-                                    </div>
+
 
                                     {!localSettings.enableYomitan && (
                                         <div style={{ marginBottom: '15px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>

--- a/WebUI/src/Manatan/components/SettingsModal.tsx
+++ b/WebUI/src/Manatan/components/SettingsModal.tsx
@@ -154,7 +154,7 @@ const getSingleGlossaryName = (value: string): string | null => {
 };
 
 const DOWNSCALE_OPTIONS = [
-    { value: '', label: 'Original Size' },
+    { value: undefined, label: 'Original Size' },
     { value: '240', label: '240' },
     { value: '360', label: '360' },
     { value: '480', label: '480' },

--- a/WebUI/src/Manatan/components/SettingsModal.tsx
+++ b/WebUI/src/Manatan/components/SettingsModal.tsx
@@ -1123,8 +1123,6 @@ ${detail}`,
                                         </label>
                                     </div>
 
-
-
                                     {!localSettings.enableYomitan && (
                                         <div style={{ marginBottom: '15px', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)' }}>
                                             <label style={{ ...checkboxLabelStyle, marginBottom: '0' }}>

--- a/WebUI/src/Manatan/components/TextBox.tsx
+++ b/WebUI/src/Manatan/components/TextBox.tsx
@@ -828,6 +828,8 @@ export const TextBox: React.FC<{
                     onComplete={handleCropperComplete}
                     onCancel={() => setShowCropper(false)}
                     quality={settings.ankiImageQuality || 0.92}
+                    downscaleMaxWidth={settings.ankiDownscaleMaxWidth}
+                    downscaleMaxHeight={settings.ankiDownscaleMaxHeight}
                 />,
                 document.body
             )}

--- a/WebUI/src/Manatan/components/TextBox.tsx
+++ b/WebUI/src/Manatan/components/TextBox.tsx
@@ -359,6 +359,10 @@ export const TextBox: React.FC<{
                 sentField || '',
                 settings.ankiImageQuality || 0.92,
                 croppedImage,
+                undefined,
+                undefined,
+                settings.ankiDownscaleMaxWidth,
+                settings.ankiDownscaleMaxHeight
             );
 
             closeDialog();

--- a/WebUI/src/Manatan/types.ts
+++ b/WebUI/src/Manatan/types.ts
@@ -124,6 +124,8 @@ export interface Settings {
     ankiConnectUrl: string;
     ankiImageQuality: number;
     ankiEnableCropper: boolean;
+    ankiDownscaleMaxWidth?: number;
+    ankiDownscaleMaxHeight?: number;
     // New Anki Settings
     ankiDeck?: string;
     ankiModel?: string;
@@ -340,6 +342,8 @@ export const DEFAULT_SETTINGS: Settings = {
     ankiConnectUrl: 'http://127.0.0.1:8765',
     ankiImageQuality: 0.92,
     ankiEnableCropper: false,
+    ankiDownscaleMaxWidth: undefined,
+    ankiDownscaleMaxHeight: undefined,
     ankiDeck: '',
     ankiModel: '',
     ankiFieldMap: {},

--- a/WebUI/src/Manatan/utils/anki.ts
+++ b/WebUI/src/Manatan/utils/anki.ts
@@ -188,11 +188,14 @@ function getCardAgeInMin(id: number) {
 }
 
 /**
- * Fetch image and convert to base64 webp using Image element (better CORS handling)
+ * Fetch image, downscale it if it exceeds max dimensions (keeping aspect ratio), 
+ * and convert to base64 webp using Image element (better CORS handling)
  */
 export async function imageUrlToBase64Webp(
     imageUrl: string,
-    quality: number = 0.92
+    quality: number = 0.92,
+    maxWidth?: number,
+    maxHeight?: number
 ): Promise<string | null> {
     return new Promise((resolve) => {
         const img = new Image();
@@ -201,11 +204,28 @@ export async function imageUrlToBase64Webp(
         
         img.onload = () => {
             try {
-                const canvas = new OffscreenCanvas(img.width, img.height);
+                let width = img.width;
+                let height = img.height;
+
+                // Calculate the scaling ratio to keep aspect ratio
+                let ratio = 1;
+                
+                if (maxWidth && width > maxWidth) {
+                    ratio = maxWidth / width;
+                }
+                if (maxHeight && (height * ratio) > maxHeight) {
+                    ratio = maxHeight / height;
+                }
+
+                // Apply ratio 
+                width = Math.round(width * ratio);
+                height = Math.round(height * ratio);
+
+                const canvas = new OffscreenCanvas(width, height);
                 const ctx = canvas.getContext('2d');
                 if (!ctx) throw new Error('No context');
-                
-                ctx.drawImage(img, 0, 0);
+
+                ctx.drawImage(img, 0, 0, width, height);
                 
                 canvas.convertToBlob({ type: 'image/webp', quality })
                     .then(blob => {
@@ -324,7 +344,9 @@ export async function updateLastCard(
     quality: number,
     preEncodedBase64?: string,
     audioField?: string,
-    audioBase64?: string
+    audioBase64?: string,
+    downscaleMaxWidth?: number,
+    downscaleMaxHeight?: number
 ) {
     // Find the last card
     const id = await getLastCardId(ankiConnectUrl);
@@ -376,7 +398,7 @@ export async function updateLastCard(
                 ? preEncodedBase64.split(';base64,')[1] 
                 : preEncodedBase64;
         } else if (imageUrl) {
-            const fullBase64 = await imageUrlToBase64Webp(imageUrl, quality);
+            const fullBase64 = await imageUrlToBase64Webp(imageUrl, quality, downscaleMaxWidth, downscaleMaxHeight);
             if (!fullBase64) throw new Error("Failed to process image (CORS or Load Error)");
             rawData = fullBase64.split(';base64,')[1];
         }

--- a/WebUI/src/Manatan/utils/anki.ts
+++ b/WebUI/src/Manatan/utils/anki.ts
@@ -1,6 +1,8 @@
 /**
  * Updated AnkiConnect API call with automatic permission handshake
  */
+import { getDownscaledSize } from './image';
+
 const ANKI_LOG_COOLDOWN_MS = 60000;
 let lastAnkiLogAt = 0;
 
@@ -204,22 +206,7 @@ export async function imageUrlToBase64Webp(
         
         img.onload = () => {
             try {
-                let width = img.width;
-                let height = img.height;
-
-                // Calculate the scaling ratio to keep aspect ratio
-                let ratio = 1;
-                
-                if (maxWidth && width > maxWidth) {
-                    ratio = maxWidth / width;
-                }
-                if (maxHeight && (height * ratio) > maxHeight) {
-                    ratio = maxHeight / height;
-                }
-
-                // Apply ratio 
-                width = Math.round(width * ratio);
-                height = Math.round(height * ratio);
+                const { width, height } = getDownscaledSize(img.width, img.height, maxWidth, maxHeight);
 
                 const canvas = new OffscreenCanvas(width, height);
                 const ctx = canvas.getContext('2d');

--- a/WebUI/src/Manatan/utils/cropper.ts
+++ b/WebUI/src/Manatan/utils/cropper.ts
@@ -80,7 +80,7 @@ export async function getCroppedImg(
             Math.round(0 - safeArea / 2 + image.height * 0.5 - pixelCrop.y)
         );
 
-        // Convert to WebP Base64 using shared utility
+        // Convert to WebP Base64
         return await canvasToBase64Webp(canvas, quality, maxWidth, maxHeight);
     } catch (error) {
         console.error('Failed to crop image:', error);
@@ -135,7 +135,7 @@ export async function getStitchedAndCroppedImg(
             );
         }
 
-        // Convert to WebP Base64 using shared utility
+        // Convert to WebP Base64
         return await canvasToBase64Webp(canvas, quality, maxWidth, maxHeight);
 
     } catch (error) {

--- a/WebUI/src/Manatan/utils/cropper.ts
+++ b/WebUI/src/Manatan/utils/cropper.ts
@@ -1,3 +1,5 @@
+import { canvasToBase64Webp } from "./image";
+
 /**
  * Creates an image from a URL
  */
@@ -32,7 +34,9 @@ export async function getCroppedImg(
     imageSrc: string,
     pixelCrop: Pixels,
     quality: number,
-    rotation = 0
+    rotation = 0,
+    maxWidth?: number,
+    maxHeight?: number
 ): Promise<string | null> {
     try {
         const image = await createImage(imageSrc);
@@ -76,18 +80,8 @@ export async function getCroppedImg(
             Math.round(0 - safeArea / 2 + image.height * 0.5 - pixelCrop.y)
         );
 
-        // Convert to WebP blob
-        const blob = await canvas.convertToBlob({
-            type: 'image/webp',
-            quality: quality
-        });
-
-        // Convert to base64
-        return new Promise((resolve) => {
-            const reader = new FileReader();
-            reader.onloadend = () => resolve(reader.result as string);
-            reader.readAsDataURL(blob);
-        });
+        // Convert to WebP Base64 using shared utility
+        return await canvasToBase64Webp(canvas, quality, maxWidth, maxHeight);
     } catch (error) {
         console.error('Failed to crop image:', error);
         return null;
@@ -98,7 +92,9 @@ export async function getStitchedAndCroppedImg(
     leftSrc: string,
     rightSrc: string,
     pixelCrop: Pixels,
-    quality: number
+    quality: number,
+    maxWidth?: number,
+    maxHeight?: number
 ): Promise<string | null> {
     try {
         const [imgL, imgR] = await Promise.all([
@@ -139,18 +135,8 @@ export async function getStitchedAndCroppedImg(
             );
         }
 
-        // Convert to WebP blob
-        const blob = await canvas.convertToBlob({ 
-            type: 'image/webp',
-            quality: quality 
-        });
-
-        // Convert to base64
-        return new Promise((resolve) => {
-            const reader = new FileReader();
-            reader.onloadend = () => resolve(reader.result as string);
-            reader.readAsDataURL(blob);
-        });
+        // Convert to WebP Base64 using shared utility
+        return await canvasToBase64Webp(canvas, quality, maxWidth, maxHeight);
 
     } catch (error) {
         console.error('Failed to crop image:', error);

--- a/WebUI/src/Manatan/utils/image.ts
+++ b/WebUI/src/Manatan/utils/image.ts
@@ -1,0 +1,45 @@
+export function getDownscaledSize(width: number, height: number, maxWidth?: number, maxHeight?: number) {
+    let ratio = 1;
+    if (maxWidth && width > maxWidth) ratio = maxWidth / width;
+    if (maxHeight && (height * ratio) > maxHeight) ratio = Math.min(ratio, maxHeight / height);
+    return {
+        width: Math.round(width * ratio),
+        height: Math.round(height * ratio)
+    };
+}
+
+
+export async function canvasToBase64Webp(
+    canvas: OffscreenCanvas,
+    quality: number,
+    maxWidth?: number,
+    maxHeight?: number
+): Promise<string | null> {
+    try {
+        let finalCanvas = canvas;
+        const { width, height } = getDownscaledSize(canvas.width, canvas.height, maxWidth, maxHeight);
+        
+        if (width !== canvas.width || height !== canvas.height) {
+            finalCanvas = new OffscreenCanvas(width, height);
+            const ctx = finalCanvas.getContext('2d');
+            if (ctx) {
+                ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, width, height);
+            }
+        }
+
+        const blob = await finalCanvas.convertToBlob({
+            type: 'image/webp',
+            quality: quality
+        });
+
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result as string);
+            reader.onerror = () => resolve(null);
+            reader.readAsDataURL(blob);
+        });
+    } catch (e) {
+        console.error("Failed to convert canvas to base64 WebP", e);
+        return null;
+    }
+}


### PR DESCRIPTION
Downscale the screenshot such that it exceeds neither the max width nor the max height that the user has set in the newly-introduced dropdowns. The aspect ratio of the page or crop is maintained.

<img width="856" height="992" alt="image" src="https://github.com/user-attachments/assets/e8f9be07-50f1-42db-9863-b49883ecc6e6" />
