### PR TITLE
feat: add MPEG-DASH (MPD) video playback support

### DIFF
--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -49,6 +49,7 @@
     "@vibrant/color": "4.0.0",
     "awaitable-component": "1.0.0",
     "csstype": "3.2.2",
+    "dashjs": "^5.1.1",
     "dayjs": "1.11.19",
     "dompurify": "3.1.7",
     "fast-average-color": "9.5.0",

--- a/WebUI/src/features/anime/reader/components/AnimeVideoPlayer.tsx
+++ b/WebUI/src/features/anime/reader/components/AnimeVideoPlayer.tsx
@@ -57,6 +57,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, Fragment } from 'rea
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useHotkeys as useHotkeysHook, useHotkeysContext } from 'react-hotkeys-hook';
 import Hls from 'hls.js';
+import { MediaPlayer as createDashPlayer, type MediaPlayerClass as DashPlayerClass } from 'dashjs';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { useLocalStorage } from '@/base/hooks/useStorage.tsx';
 import { Hotkey } from '@/features/reader/hotkeys/settings/components/Hotkey.tsx';
@@ -140,6 +141,8 @@ type Props = {
     currentEpisodeIndex?: number | null;
     onEpisodeSelect?: (index: number) => void;
     isHlsSource: boolean;
+    isDashSource?: boolean;
+    dashHeaders?: Record<string, string>;
     videoOptions: VideoOption[];
     selectedVideoIndex: number;
     onVideoChange: (index: number) => void;
@@ -579,6 +582,8 @@ export const AnimeVideoPlayer = ({
     currentEpisodeIndex = null,
     onEpisodeSelect,
     isHlsSource,
+    isDashSource = false,
+    dashHeaders,
     videoOptions,
     selectedVideoIndex,
     onVideoChange,
@@ -757,6 +762,7 @@ export const AnimeVideoPlayer = ({
     const braveResetPendingRef = useRef(false);
     const userPausedRef = useRef(false);
     const hlsRef = useRef<Hls | null>(null);
+    const dashPlayerRef = useRef<dashjs.MediaPlayerClass | null>(null);
     const hlsManifestReadyRef = useRef(false);
     const braveResetScheduledRef = useRef(false);
     const braveScheduleRef = useRef<((instance: Hls) => void) | null>(null);
@@ -1391,6 +1397,47 @@ export const AnimeVideoPlayer = ({
             video.play().catch(() => {});
         };
 
+        if (isDashSource) {
+            const player = createDashPlayer().create();
+            player.updateSettings({
+                streaming: {
+                    buffer: {
+                        fastSwitchEnabled: true,
+                    },
+                },
+            });
+            if (dashHeaders && Object.keys(dashHeaders).length > 0) {
+                player.extend('RequestModifier', () => ({
+                    modifyRequestHeader(xhr: XMLHttpRequest) {
+                        for (const [key, value] of Object.entries(dashHeaders)) {
+                            xhr.setRequestHeader(key, value);
+                        }
+                        return xhr;
+                    },
+                    modifyRequestURL(url: string) {
+                        return url;
+                    },
+                }), true);
+            }
+            dashPlayerRef.current = player;
+            player.initialize(video, videoSrc, false);
+            const onStreamInitialized = () => {
+                userPausedRef.current = false;
+                attemptPlay(true);
+            };
+            player.on('streamInitialized', onStreamInitialized);
+            return () => {
+                if (playTimeout !== null) {
+                    window.clearTimeout(playTimeout);
+                }
+                player.off('streamInitialized', onStreamInitialized);
+                player.destroy();
+                dashPlayerRef.current = null;
+                clearBraveResets();
+                restoreBraveAudio();
+            };
+        }
+
         if (!shouldUseHls) {
             video.src = videoSrc;
             video.load();
@@ -1479,6 +1526,8 @@ export const AnimeVideoPlayer = ({
     }, [
         videoSrc,
         isHlsSource,
+        isDashSource,
+        dashHeaders,
         isBrave,
         isBraveLinux,
         braveBufferSeconds,

--- a/WebUI/src/features/anime/reader/screens/AnimeEpisode.tsx
+++ b/WebUI/src/features/anime/reader/screens/AnimeEpisode.tsx
@@ -53,6 +53,9 @@ type VideoResponse = {
     proxyUrl: string;
     videoUrl: string;
     isHls: boolean;
+    containerHint?: string | null;
+    ffmpegSourceUrl?: string | null;
+    headers?: Array<{ first: string; second: string }> | null;
     subtitleTracks: Array<{ url: string; lang: string }>;
 };
 
@@ -298,6 +301,21 @@ export const AnimeEpisode = () => {
             isLikelyHlsUrl(currentVideo?.proxyUrl) ||
             isLikelyHlsUrl(currentVideo?.videoUrl),
     );
+    const isDashSource = Boolean(
+        !isHlsSource && (
+            currentVideo?.containerHint === 'mpd' ||
+            /\.mpd(\?|$)/i.test(currentVideo?.videoUrl ?? '') ||
+            /\.mpd(\?|$)/i.test(currentVideo?.proxyUrl ?? '')
+        ),
+    );
+    const dashHeaders = useMemo(() => {
+        if (!isDashSource || !currentVideo?.headers) return undefined;
+        const h: Record<string, string> = {};
+        for (const { first, second } of currentVideo.headers) {
+            h[first] = second;
+        }
+        return h;
+    }, [isDashSource, currentVideo?.headers]);
     const proxyBaseUrl = currentVideo?.proxyUrl
         ? currentVideo.proxyUrl.startsWith('http')
             ? currentVideo.proxyUrl
@@ -310,7 +328,10 @@ export const AnimeEpisode = () => {
     const playlistSrc = !isDirectVideo && isHlsSource && id && episodeIndex
         ? `${requestManager.getBaseUrl()}/api/v1/anime/${id}/episode/${episodeIndex}/video/${resolvedVideoIndex}/playlist`
         : null;
-    const videoSrc = playlistSrc ?? proxyBaseUrl ?? '';
+    const dashSrc = isDashSource && currentVideo?.ffmpegSourceUrl
+        ? currentVideo.ffmpegSourceUrl
+        : null;
+    const videoSrc = playlistSrc ?? dashSrc ?? proxyBaseUrl ?? '';
     const enableBraveAudioFix = Boolean(videoSrc && isHlsSource);
     const videoLabel = useMemo(
         () =>
@@ -592,6 +613,8 @@ export const AnimeEpisode = () => {
             currentEpisodeIndex={currentEpisodeIndex}
             onEpisodeSelect={handleEpisodeSelect}
             isHlsSource={Boolean(videoSrc && isHlsSource)}
+            isDashSource={Boolean(videoSrc && isDashSource)}
+            dashHeaders={dashHeaders}
             videoOptions={videoLabel.map((label, index) => ({ label, index }))}
             selectedVideoIndex={resolvedVideoIndex}
             onVideoChange={handleVideoChange}


### PR DESCRIPTION
## Summary
- Add `dash.js` to handle MPEG-DASH video playback for anime extensions returning MPD sources (e.g. Anime Onsen)
- The player previously only supported HLS via `hls.js`, causing `MEDIA_ERR_SRC_NOT_SUPPORTED` for DASH content
- DASH sources are detected via `containerHint` from the API or `.mpd` URL pattern, and played directly from CDN with custom header injection

## Changes
- **`AnimeEpisode.tsx`**: Extended `VideoResponse` type with `containerHint`, `ffmpegSourceUrl`, `headers`. Added `isDashSource` detection and routes DASH sources to the original CDN URL
- **`AnimeVideoPlayer.tsx`**: Integrated `dash.js` `MediaPlayer` with `RequestModifier` for custom headers and proper cleanup
- **`package.json`**: Added `dashjs@5.1.1`

## Test plan
- [x] Verified DASH playback with Anime Onsen extension (Yomi no Tsugai ep1)
- [ ] Verify HLS sources still work with other extensions
- [ ] Test on mobile/Android webview
- [ ] Test with Brave browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)