### PR TITLE
Bind Android local servers to loopback

### DIFF
--- a/bin/manatan_android/java/com/mangatan/app/AnkiBridge.java
+++ b/bin/manatan_android/java/com/mangatan/app/AnkiBridge.java
@@ -94,10 +94,12 @@ public class AnkiBridge {
 
         new Thread(() -> {
             try {
-                // Bind to 0.0.0.0 to allow connections from any IP
+                // Keep the bridge local to the device. The WebView and native app
+                // only need loopback access, and exposing this on LAN widens the
+                // attack surface for public or shared networks.
                 serverSocket = new ServerSocket();
-                serverSocket.bind(new InetSocketAddress("0.0.0.0", 8765));
-                Log.i(TAG, "✅ AnkiConnect listening on 0.0.0.0:8765");
+                serverSocket.bind(new InetSocketAddress("127.0.0.1", 8765));
+                Log.i(TAG, "✅ AnkiConnect listening on 127.0.0.1:8765");
 
                 while (serverRunning) {
                     try {

--- a/bin/manatan_android/src/lib.rs
+++ b/bin/manatan_android/src/lib.rs
@@ -1283,8 +1283,8 @@ async fn start_web_server(
         .fallback(serve_react_app)
         .layer(cors);
 
-    let listener = TcpListener::bind("0.0.0.0:4568").await?;
-    info!("✅ Web Server listening on 0.0.0.0:4568");
+    let listener = TcpListener::bind("127.0.0.1:4568").await?;
+    info!("✅ Web Server listening on 127.0.0.1:4568");
     axum::serve(listener, app).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Bind the Android Web UI server to `127.0.0.1` instead of `0.0.0.0`
- Bind the Android AnkiConnect bridge to `127.0.0.1` instead of `0.0.0.0`
- Add a short comment explaining why the Anki bridge should remain device-local by default

## Rationale
The Android WebView/native app flows use loopback URLs, so the local servers do not need to listen on all network interfaces by default.

Listening on `0.0.0.0` makes these local helper services reachable from other devices on the same Wi-Fi/LAN. That is broader than the same-device WebView use case and can be surprising on public or shared networks, especially because the Android Web UI and AnkiConnect-style bridge expose app-local actions over HTTP. Binding to loopback by default keeps the existing same-device flow working while avoiding unnecessary network exposure.

If cross-device/LAN access is intended for some workflows, it would be safer as an explicit opt-in setting rather than the default bind behavior.

## Test plan
- [x] Verified the Android server URLs in code still target loopback addresses (`127.0.0.1`)
- [x] Verified the branch is pushed to the fork and the draft PR targets `KolbyML/Manatan:master`
- [ ] Android runtime test on device or emulator
- [ ] Confirm any intended cross-device/LAN workflows are not required by default